### PR TITLE
feat(cardset): add need fields to GetCardset response

### DIFF
--- a/controller/cardset.go
+++ b/controller/cardset.go
@@ -146,12 +146,27 @@ func GetCardset(c echo.Context) error {
 		cardsIDs = append(cardsIDs, c.ID.Hex())
 	}
 
+	user, _, err := m.GetUser(cardset.OwnerID.Hex())
+	if err != nil {
+		return context.Error(c, http.StatusInternalServerError, "error when get cardset owner", err)
+	}
+
+	err = m.UpdateVisitCount(cardsetID)
+	if err != nil {
+		return context.Error(c, http.StatusInternalServerError, "error when UpdateVisitCount", err)
+	}
+
 	resp := param.GetCardsetResponse{
-		ID:          cardsetID,
-		Name:        cardset.Name,
-		Description: cardset.Description,
-		Access:      cardset.Access,
-		Cards:       cardsIDs,
+		ID:            cardsetID,
+		OwnerID:       cardset.OwnerID.Hex(),
+		OwnerName:     user.Username,
+		Name:          cardset.Name,
+		Description:   cardset.Description,
+		FavoriteCount: cardset.FavoriteCount,
+		VisitCount:    cardset.VisitCount,
+		Access:        cardset.Access,
+		CreateTime:    cardset.CreateTime,
+		Cards:         cardsIDs,
 	}
 	return context.Success(c, resp)
 }

--- a/controller/param/cardset.go
+++ b/controller/param/cardset.go
@@ -22,9 +22,14 @@ type RandomCardsetsRequest struct {
 }
 
 type GetCardsetResponse struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Access      int      `json:"access"`
-	Cards       []string `json:"cards"`
+	ID            string   `json:"id"`
+	OwnerID       string   `json:"owner_id"`
+	OwnerName     string   `json:"owner_name"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	Access        int      `json:"access"`
+	FavoriteCount int      `json:"favorite_count"`
+	VisitCount    int      `json:"visit_count"`
+	CreateTime    int64    `json:"create_time"`
+	Cards         []string `json:"cards"`
 }

--- a/controller/user.go
+++ b/controller/user.go
@@ -155,10 +155,18 @@ func UpdateFavorite(c echo.Context) error {
 
 	userID := context.GetJWTUserID(c)
 
-	err = m.UpdateFavorite(userID, p.CardsetID, p.Liked)
+	modified, err := m.UpdateFavorite(userID, p.CardsetID, p.Liked)
 	if err != nil {
 		return context.Error(c, http.StatusInternalServerError, "error when UpdateUser", err)
 	}
+
+	if modified {
+		err = m.UpdateFavoriteCount(p.CardsetID, p.Liked)
+		if err != nil {
+			return context.Error(c, http.StatusInternalServerError, "error when UpdateFavoriteCount", err)
+		}
+	}
+
 	return context.Success(c, "ok")
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -386,6 +386,11 @@ Authorization: Bearer 一个巨长的 token
 
 - name：字符串，名称
 - description：字符串，卡片集描述
+- owner_id：字符串，创建者id
+- owner_name：字符串，创建者用户名
+- favorite_count：字符串，收藏数量
+- visit_count：字符串，访问数量
+- create_time：整数，创建时间戳
 - access：整数，访问权限
 - cards：字符串数组，卡片的 id 列表
 
@@ -396,6 +401,11 @@ Authorization: Bearer 一个巨长的 token
   "id": "id",
   "name": "test-cards",
   "description": "test test.",
+  "owner_id": "6194e37bd786c6c07ea8a4fb",
+  "owner_name": "test",
+  "favorite_count": 1,
+  "visit_count": 7,
+  "create_time": 1637469245,
   "access": 1,
   "cards": []
 }


### PR DESCRIPTION
获取卡片集的API新增以下响应字段

- owner_id：字符串，创建者id
- owner_name：字符串，创建者用户名
- favorite_count：字符串，收藏数量
- visit_count：字符串，访问数量
- create_time：整数，创建时间戳

详见 docs/api.md

@xiong35 @gucan707 check下是否满足需求