### PR TITLE
feat: add comment time field for response

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -104,7 +105,8 @@ func GetComments(c echo.Context) error {
 				Username: user.Username,
 				Avatar:   user.Avatar,
 			},
-			Comment: cmt.Content,
+			Comment:    cmt.Content,
+			LastUpdate: fmt.Sprintf("%d", cmt.LastUpdateTime),
 		})
 	}
 

--- a/controller/param/comment.go
+++ b/controller/param/comment.go
@@ -5,9 +5,10 @@ type NewCommentRequest struct {
 }
 
 type CommentResponseItem struct {
-	ID      string       `json:"id"`
-	Owner   UserResponse `json:"owner"`
-	Comment string       `json:"comment"`
+	ID         string       `json:"id"`
+	Owner      UserResponse `json:"owner"`
+	Comment    string       `json:"comment"`
+	LastUpdate string       `json:"lastupdate"`
 }
 
 type GetCommentResponse = []CommentResponseItem

--- a/docs/api.md
+++ b/docs/api.md
@@ -648,7 +648,9 @@ GET /cardset/6193c1cfd9598aa1a050b041/card?ids=["6199cc46b4600da8e6102dad","619b
 
 #### 响应参数
 
-数组，每个元素包含**该条评论的 ID**, **发表评论的用户**和**评论内容**
+数组，每个元素包含**该条评论的 ID**, **发表评论的用户**, **评论内容**以及**评论最后一次更新时间**。
+
+注：评论最后一次更新时间在默认情况下为发表评论时间，以Unix时间戳表示，如`1638775217`表示`2021-12-06 15:20:17 +0800 CST`。
 
 #### 响应示例
 
@@ -661,7 +663,8 @@ GET /cardset/6193c1cfd9598aa1a050b041/card?ids=["6199cc46b4600da8e6102dad","619b
       "username": "xxx",
       "avatar": "https://example.com/a.jpg"
     },
-    "comment": "comment"
+    "comment": "comment",
+    "lastupdate": "1638775217"
   },
   {
     "id": "id",
@@ -670,7 +673,8 @@ GET /cardset/6193c1cfd9598aa1a050b041/card?ids=["6199cc46b4600da8e6102dad","619b
       "username": "xxx",
       "avatar": "https://example.com/a.jpg"
     },
-    "comment": "comment"
+    "comment": "comment",
+    "lastupdate": "1638775217"
   }
 ]
 ```


### PR DESCRIPTION
Closed #24 

Add the field of last update time as the comment time in the response of `GET  /cardset/:cardset_id/card/:id/comment`, the time field is formatted to Unix timestamp.

Example of new response:
```json
[
  {
    "id": "id",
    "owner": {
      "id": "id",
      "username": "xxx",
      "avatar": "https://example.com/a.jpg"
    },
    "comment": "comment",
    "lastupdate": "1638775217"
  }
]
```
In the **lastupdate** field, `1638775217` represents `2021-12-06 15:20:17 +0800 CST`.